### PR TITLE
plexamp: use nix-instantiate

### DIFF
--- a/.github/workflows/upkeep.yml
+++ b/.github/workflows/upkeep.yml
@@ -192,7 +192,7 @@ jobs:
         working-directory: ./nixpkgs
         run: |
           PACKAGE="plexamp"
-          CURRENT_VERSION="$(nix eval --raw -f . $PACKAGE.version)"
+          CURRENT_VERSION="$(nix-instantiate --eval -E 'with import ./. {}; lib.getVersion plexamp' --json | jq -r)"
           echo "PACKAGE=$PACKAGE" >> $GITHUB_ENV
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
Plexamp doesn't have a version attribute because the builder we use doesn't support that. Until https://github.com/NixOS/nixpkgs/pull/124520 is merged, we have to use a bit of a workaround.

Should fix #7 